### PR TITLE
fix(ci): stabilize CI test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
 
     - name: Execute tests (Unit and Feature tests) via PHPUnit
       run: |
-        if [ -f artisan ]; then
-          php artisan test --colors=never
-        elif [ -f vendor/bin/phpunit ]; then
+        if [ -f vendor/bin/phpunit ]; then
           vendor/bin/phpunit --colors=never
         else
-          echo "No test runner found; skipping tests."
+          php -v || true
+          ls -la vendor || true
+          echo "PHPUnit not found; attempting artisan test"
+          php artisan test --colors=never
         fi
-      working-directory: ${{ github.workspace }}
 
     - name: Upload logs on failure
       if: failure()


### PR DESCRIPTION
Summary: Run vendor/bin/phpunit by default with fallback to artisan test to avoid non-zero exit edge cases.\nAffected commands: CI workflow only\nManual test: ✅ local passes, CI run expected to go green\nRollback: git revert <squash-commit>